### PR TITLE
chore: upgrade go to latest release

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -27,6 +27,8 @@ builds:
     ignore:
       - goos: darwin
         goarch: '386'
+      - goos: windows
+        goarch: arm
     binary: '{{ .ProjectName }}_v{{ .Version }}'
 archives:
   - formats: zip

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ This amounts to creating or updating a `~/.terraformrc` file with contents of:
 provider_installation {
 
   dev_overrides {
-      "github.com/digipost/pass" = "${GOPATH}/bin"
+      "digipost/pass" = "${GOPATH}/bin"
   }
 
   # For all other providers, install them directly from their origin provider
@@ -60,23 +60,28 @@ environment variable substitution in that file, does not work.
 terraform {
   required_providers {
     pass = {
-      source = "github.com/digipost/pass"
+      source  = "digipost/pass"
     }
   }
 }
-
 provider "pass" {
-  store_dir = "<YOUR pass store directory, e.g. ~/.password-store>"
+  store_dir = "./test"
   refresh_store = false
 }
 
+resource "pass_password" "test" {
+  path = "/foo/bar/username"
+  password = "mysecretpassword"
+}
 
 data "pass_password" "test" {
-  path = "<some secret path in the password store, /foo/bar/username >"
+  path = "/foo/bar/username"
+  depends_on = [ pass_password.test ]
 }
 
 output "testdata" {
   value = data.pass_password.test
+}
 
 ```
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/digipost/terraform-provider-pass
 
-go 1.25.0
+go 1.26.1
 
 require (
 	github.com/blang/semver v3.5.1+incompatible


### PR DESCRIPTION
Remove invalid architecture from goreleaser config. Update README with description of local, manual Terraform test. In recent version of Terraform, you need to use a real module source identifier, not just a random string.